### PR TITLE
Custom argument parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Hevi is a hex viewer, just like `xxd` or `hexdump`.
 Hevi is under development. But if you think it's missing any feature, please open an issue. I will address it as soon as possible.
 
 ## About
-It is written in [zig](https://github.com/ziglang/zig), and uses [clap](https://github.com/Hejsil/zig-clap) as a CLI parser.
+It is written in [zig](https://github.com/ziglang/zig), in an attempt to simplify hex viewers.
 
 ## Contribute
 Contributions are welcome! Even if you don't want to write code, you can help a lot creating new issues or testing this software.

--- a/build.zig
+++ b/build.zig
@@ -12,13 +12,6 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
 
-    const clap = b.dependency("clap", .{
-        .target = target,
-        .optimize = optimize,
-    });
-
-    exe.addModule("clap", clap.module("clap"));
-
     b.installArtifact(exe);
 
     const run_cmd = b.addRunArtifact(exe);

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,12 +1,7 @@
 .{
     .name = "hevi",
     .version = "0.1.0",
-    .dependencies = .{
-        .clap = .{
-            .url = "https://github.com/Hejsil/zig-clap/archive/refs/heads/master.tar.gz",
-            .hash = "122066d86920926a4a674adaaa10f158dc4961c2a47e588e605765455d74ca72c2ad",
-        }
-    },
+    .dependencies = .{},
     .paths = .{
         "",
     },


### PR DESCRIPTION
Stop using `clap` and start using a hand-written argument parser.

Fixes #9