### PR TITLE
Implement `--version` arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The command should be used as `hevi <file> [flags]`. The flags are described [be
 | Flag(s)                     | Description                                             |
 | --------------------------- | ------------------------------------------------------- |
 | `-h`/`--help`               | Show a help message                                     |
+| `-v`/`--version`            | Show version information                                |
 | `--color`/`--no-color`      | Enable and disable colored output                       |
 | `--lowercase`/`--uppercase` | Toggle between lowercase and uppercase hex              |
 | `--size`/`--no-size`        | Enable and disable the line showing the size at the end |

--- a/build.zig
+++ b/build.zig
@@ -10,7 +10,7 @@ fn getVersion(b: *std.Build) SemanticVersion {
     var buf: [2]Ast.Node.Index = undefined;
     const build_zon = ast.fullStructInit(&buf, ast.nodes.items(.data)[0].lhs) orelse @panic("Cannot parse build.zig.zon");
 
-    const version: SemanticVersion = r: {
+    var version: SemanticVersion = r: {
         for (build_zon.ast.fields) |field| {
             const field_name = ast.tokenSlice(ast.firstToken(field) - 2);
 
@@ -29,6 +29,7 @@ fn getVersion(b: *std.Build) SemanticVersion {
         "--tags",
         "--abbrev=10",
     }, &code, .Ignore) catch {
+        version.pre = "dev";
         return version;
     }, "\n\r");
 
@@ -49,7 +50,10 @@ fn getVersion(b: *std.Build) SemanticVersion {
                 .build = commit_id[1..],
             };
         },
-        else => return version,
+        else => {
+            version.pre = "dev";
+            return version;
+        },
     }
 }
 

--- a/build.zig
+++ b/build.zig
@@ -1,5 +1,33 @@
 const std = @import("std");
 
+const VERSION = "1.0.0";
+
+fn getVersion(b: *std.Build) []const u8 {
+    var code: u8 = undefined;
+    const git_version_cmd = std.mem.trim(u8, b.runAllowFail(&[_][]const u8{
+        "git",
+        "describe",
+        "--tags",
+        "--abbrev=10",
+    }, &code, .Ignore) catch {
+        return VERSION;
+    }, "\n\r");
+
+    switch (std.mem.count(u8, git_version_cmd, "-")) {
+        0 => return git_version_cmd, // Here VERSION == git_version_cmd
+        2 => {
+            var splitted = std.mem.splitScalar(u8, git_version_cmd, '-');
+            _ = splitted.first(); // Git tag
+            const commit_num = splitted.next() orelse @panic("Wrong `git describe` output!");
+            const commit_id = splitted.next() orelse @panic("Wrong `git describe` output!");
+
+            // The commit_id always starts with 'g' (for indicate that git was used), so we can skip it
+            return b.fmt("{s}-dev.{s}+{s}", .{ VERSION, commit_num, commit_id[1..] });
+        },
+        else => return VERSION,
+    }
+}
+
 pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
 
@@ -11,6 +39,10 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
     });
+
+    var build_options = b.addOptions();
+    build_options.addOption([]const u8, "version", getVersion(b));
+    exe.root_module.addOptions("build_options", build_options);
 
     b.installArtifact(exe);
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = "hevi",
-    .version = "1.0.0-dev",
+    .version = "1.0.0",
     .dependencies = .{},
     .paths = .{
         "",

--- a/src/argparse.zig
+++ b/src/argparse.zig
@@ -55,7 +55,7 @@ fn printHelp() noreturn {
 fn printVersion() noreturn {
     const version = build_options.version;
 
-    if (version.pre != null) {
+    if (version.build != null) {
         // Development version
         std.debug.print(
             \\hevi {d}.{d}.{d}-{s}+{s}
@@ -66,6 +66,17 @@ fn printVersion() noreturn {
             version.patch,
             version.pre.?,
             version.build.?,
+        });
+    } else if (version.pre != null) {
+        // Development version because git information is not available
+        std.debug.print(
+            \\hevi {d}.{d}.{d}-{s}
+            \\
+        , .{
+            version.major,
+            version.minor,
+            version.patch,
+            version.pre.?,
         });
     } else {
         // Tagged version

--- a/src/argparse.zig
+++ b/src/argparse.zig
@@ -1,3 +1,4 @@
+const build_options = @import("build_options");
 const std = @import("std");
 
 const ParseResult = struct {
@@ -14,6 +15,7 @@ const Flag = union(enum) {
         flag: []const u8,
         action: enum {
             help,
+            version,
         },
     },
     toggle: struct {
@@ -37,6 +39,7 @@ fn printHelp() noreturn {
         \\
         \\Flags:
         \\  -h, --help                  Print this help message
+        \\  -v, --version               Print version information
         \\  --color, --no-color         Enable or disable output coloring
         \\  --lowercase, --uppercase    Switch between lowercase and uppercase hex
         \\  --size, --no-size           Enable or disable showing the size at the end
@@ -46,6 +49,14 @@ fn printHelp() noreturn {
         \\Made by Arnau478
         \\
     , .{});
+    std.process.exit(0);
+}
+
+fn printVersion() noreturn {
+    std.debug.print(
+        \\hevi {s}
+        \\
+    , .{build_options.version});
     std.process.exit(0);
 }
 
@@ -66,12 +77,16 @@ pub fn parse(args: [][]const u8) ParseResult {
                 'h' => {
                     printHelp();
                 },
+                'v' => {
+                    printVersion();
+                },
                 '-' => {
                     const name = arg[2..];
                     if (name.len == 0) printError("expected flag", .{});
 
                     const flags: []const Flag = &.{
                         .{ .action = .{ .flag = "help", .action = .help } },
+                        .{ .action = .{ .flag = "version", .action = .version } },
                         .{ .toggle = .{ .boolean = &color, .enable = "color", .disable = "no-color" } },
                         .{ .toggle = .{ .boolean = &uppercase, .enable = "uppercase", .disable = "lowercase" } },
                         .{ .toggle = .{ .boolean = &show_size, .enable = "size", .disable = "no-size" } },
@@ -86,6 +101,7 @@ pub fn parse(args: [][]const u8) ParseResult {
                                     if (std.mem.eql(u8, name, action.flag)) {
                                         switch (action.action) {
                                             .help => printHelp(),
+                                            .version => printVersion(),
                                         }
                                         break :blk true;
                                     }

--- a/src/argparse.zig
+++ b/src/argparse.zig
@@ -53,10 +53,28 @@ fn printHelp() noreturn {
 }
 
 fn printVersion() noreturn {
-    std.debug.print(
-        \\hevi {s}
-        \\
-    , .{build_options.version});
+    const version = build_options.version;
+
+    if (version.pre != null) {
+        // Development version
+        std.debug.print(
+            \\hevi {d}.{d}.{d}-{s}+{s}
+            \\
+        , .{
+            version.major,
+            version.minor,
+            version.patch,
+            version.pre.?,
+            version.build.?,
+        });
+    } else {
+        // Tagged version
+        std.debug.print(
+            \\hevi {d}.{d}.{d}
+            \\
+        , .{ version.major, version.minor, version.patch });
+    }
+
     std.process.exit(0);
 }
 


### PR DESCRIPTION
**This PR adds the `--version` argument** (as well as `-v`) **to get information about the version of hevi built.**

---

When git is available, the build system tries to get the information to generate the version string from
`git describe --tags`. The format of the version taken from git is `x.x.x-dev.n+h`, where `n` is the commit number (starting with the last tag) and where `h` is the hash of the last commit.

If git is unavailable or an error occurs, the version string defaults to the one written in `build.zig`.

Also, the version is not taken from `build.zig.zon` because there is no function or variable to get it from there (the only way is to parse the zon file, but I don't think that is necessary).