### PR TITLE
Support OpenBSD and update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The command should be used as `hevi <file> [flags]`. The flags are described [be
 The `NO_COLOR` variable is supported, and disables color (see <https://no-color.org/>) printing. Note that it can be overwritten by an explicit `--color`.
 
 ### Config file
-You can create a file named `~/.config/hevi/config.zon`, and specify the default values for the flags. It follows the `.zon` syntax. Example:
+You can create a config file and specify the default values for the flags. It follows the `.zon` syntax. Example:
 ```zig
 .{
     .color = true,
@@ -38,6 +38,19 @@ You can create a file named `~/.config/hevi/config.zon`, and specify the default
     .show_ascii = false,
 }
 ```
+
+The config file is located at:
+| OS                                     | Path                                                                                            |
+| -------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| Linux, MacOS, FreeBSD, OpenBSD, NetBSD | `$XDG_CONFIG_HOME/hevi/config.zon` or if the env doesn't exist `$HOME/.config/hevi/config.zon`  |
+| Windows                                | `%APPDATA%/hevi/config.zon`                                                                     |
+| Other                                  | Not supported. No config file will be read                                                      |
+
+**Note**: hevi has a precedence for configuration and is:
+1. Flags
+2. Environment variables
+3. Config file
+4. Defaults
 
 ## About
 It is written in [zig](https://github.com/ziglang/zig), in an attempt to simplify hex viewers.

--- a/src/main.zig
+++ b/src/main.zig
@@ -115,7 +115,7 @@ fn display(reader: anytype, writer: anytype, options: DisplayOptions) !void {
 
 fn openConfigFile(env_map: std.process.EnvMap) ?std.fs.File {
     const path: ?[]const u8 = switch (builtin.os.tag) {
-        .linux, .macos, .freebsd, .netbsd => if (env_map.get("XDG_CONFIG_HOME")) |xdg_config_home|
+        .linux, .macos, .freebsd, .openbsd, .netbsd => if (env_map.get("XDG_CONFIG_HOME")) |xdg_config_home|
             std.fs.path.join(allocator, &.{ xdg_config_home, "hevi/config.zon" }) catch null
         else if (env_map.get("HOME")) |home|
             std.fs.path.join(allocator, &.{ home, ".config/hevi/config.zon" }) catch null


### PR DESCRIPTION
Add support for OpenBSD and update the README with information about the path of the configuration file and the precedence of the configuration "methods".