### PR TITLE
Move the option/config code to `options.zig`

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -1,10 +1,11 @@
 const std = @import("std");
-const builtin = @import("builtin");
 const argparse = @import("argparse.zig");
+const hoptions = @import("options.zig");
+const DisplayOptions = hoptions.DisplayOptions;
 const NormalizedSize = @import("NormalizedSize.zig");
 
 var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-const allocator = gpa.allocator();
+pub const allocator = gpa.allocator();
 
 inline fn isPrintable(c: u8) bool {
     return switch (c) {
@@ -73,14 +74,6 @@ fn displayLine(line: []const u8, writer: anytype, options: DisplayLineOptions) !
     try writer.print("\n", .{});
 }
 
-const DisplayOptions = struct {
-    color: bool,
-    uppercase: bool,
-    show_size: bool,
-    show_offset: bool,
-    show_ascii: bool,
-};
-
 fn display(reader: anytype, writer: anytype, options: DisplayOptions) !void {
     var count: usize = 0;
 
@@ -113,93 +106,6 @@ fn display(reader: anytype, writer: anytype, options: DisplayOptions) !void {
     }
 }
 
-fn openConfigFile(env_map: std.process.EnvMap) ?std.fs.File {
-    const path: ?[]const u8 = switch (builtin.os.tag) {
-        .linux, .macos, .freebsd, .openbsd, .netbsd => if (env_map.get("XDG_CONFIG_HOME")) |xdg_config_home|
-            std.fs.path.join(allocator, &.{ xdg_config_home, "hevi/config.zon" }) catch null
-        else if (env_map.get("HOME")) |home|
-            std.fs.path.join(allocator, &.{ home, ".config/hevi/config.zon" }) catch null
-        else
-            null,
-        .windows => if (env_map.get("APPDATA")) |appdata|
-            std.fs.path.join(allocator, &.{ appdata, "hevi/config.zon" }) catch null
-        else
-            null,
-        else => null,
-    };
-
-    return std.fs.openFileAbsolute(path orelse return null, .{}) catch null;
-}
-
-fn getOptions(args: argparse.ParseResult, stdout: std.fs.File) !DisplayOptions {
-    var envs = try std.process.getEnvMap(allocator);
-    defer envs.deinit();
-
-    // Default values
-    var options = DisplayOptions{
-        .color = stdout.supportsAnsiEscapeCodes(),
-        .uppercase = false,
-        .show_size = true,
-        .show_offset = true,
-        .show_ascii = true,
-    };
-
-    // Config file
-    if (openConfigFile(envs)) |file| {
-        defer file.close();
-
-        const stderr = std.io.getStdErr();
-        defer stderr.close();
-
-        const source = try file.readToEndAllocOptions(allocator, std.math.maxInt(usize), null, 1, 0);
-        defer allocator.free(source);
-
-        var ast = try std.zig.Ast.parse(allocator, source, .zon);
-        defer ast.deinit(allocator);
-
-        var buf: [2]std.zig.Ast.Node.Index = undefined;
-        const root = ast.fullStructInit(&buf, ast.nodes.items(.data)[0].lhs) orelse {
-            try stderr.writer().print("Error: Config file does not contain a struct literal\n", .{});
-            return error.InvalidConfig;
-        };
-
-        for (root.ast.fields) |field| {
-            const name = ast.tokenSlice(ast.firstToken(field) - 2);
-            const slice = ast.tokenSlice(ast.firstToken(field));
-            const value = if (ast.tokens.get(ast.firstToken(field)).tag == .identifier and std.mem.eql(u8, slice, "true"))
-                true
-            else if (ast.tokens.get(ast.firstToken(field)).tag == .identifier and std.mem.eql(u8, slice, "false"))
-                false
-            else {
-                try stderr.writer().print("Error: Expected a bool for field {s} in config file\n", .{name});
-                return error.InvalidConfig;
-            };
-            const field_ptr = blk: {
-                inline for (std.meta.fields(DisplayOptions)) |opt_field| {
-                    if (std.mem.eql(u8, name, opt_field.name)) break :blk &@field(options, opt_field.name);
-                }
-                try stderr.writer().print("Error: Invalid field in config file: {s}\n", .{name});
-                return error.InvalidConfig;
-            };
-            field_ptr.* = value;
-        }
-    }
-
-    // Environment variables
-    if (envs.get("NO_COLOR")) |s| {
-        if (!std.mem.eql(u8, s, "")) options.color = false;
-    }
-
-    // Flags
-    if (args.color) |color| options.color = color;
-    if (args.uppercase) |uppercase| options.uppercase = uppercase;
-    if (args.show_size) |show_size| options.show_size = show_size;
-    if (args.show_offset) |show_offset| options.show_offset = show_offset;
-    if (args.show_ascii) |show_ascii| options.show_ascii = show_ascii;
-
-    return options;
-}
-
 pub fn main() !void {
     const args = try std.process.argsAlloc(allocator);
     defer std.process.argsFree(allocator, args);
@@ -211,5 +117,5 @@ pub fn main() !void {
 
     const stdout = std.io.getStdOut();
 
-    try display(file.reader(), stdout.writer(), try getOptions(parsed_args, stdout));
+    try display(file.reader(), stdout.writer(), try hoptions.getOptions(parsed_args, stdout));
 }

--- a/src/options.zig
+++ b/src/options.zig
@@ -1,0 +1,100 @@
+const builtin = @import("builtin");
+const std = @import("std");
+const argparse = @import("argparse.zig");
+
+const allocator = @import("main.zig").allocator;
+
+pub const DisplayOptions = struct {
+    color: bool,
+    uppercase: bool,
+    show_size: bool,
+    show_offset: bool,
+    show_ascii: bool,
+};
+
+fn openConfigFile(env_map: std.process.EnvMap) ?std.fs.File {
+    const path: ?[]const u8 = switch (builtin.os.tag) {
+        .linux, .macos, .freebsd, .openbsd, .netbsd => if (env_map.get("XDG_CONFIG_HOME")) |xdg_config_home|
+            std.fs.path.join(allocator, &.{ xdg_config_home, "hevi/config.zon" }) catch null
+        else if (env_map.get("HOME")) |home|
+            std.fs.path.join(allocator, &.{ home, ".config/hevi/config.zon" }) catch null
+        else
+            null,
+        .windows => if (env_map.get("APPDATA")) |appdata|
+            std.fs.path.join(allocator, &.{ appdata, "hevi/config.zon" }) catch null
+        else
+            null,
+        else => null,
+    };
+
+    return std.fs.openFileAbsolute(path orelse return null, .{}) catch null;
+}
+
+pub fn getOptions(args: argparse.ParseResult, stdout: std.fs.File) !DisplayOptions {
+    var envs = try std.process.getEnvMap(allocator);
+    defer envs.deinit();
+
+    // Default values
+    var options = DisplayOptions{
+        .color = stdout.supportsAnsiEscapeCodes(),
+        .uppercase = false,
+        .show_size = true,
+        .show_offset = true,
+        .show_ascii = true,
+    };
+
+    // Config file
+    if (openConfigFile(envs)) |file| {
+        defer file.close();
+
+        const stderr = std.io.getStdErr();
+        defer stderr.close();
+
+        const source = try file.readToEndAllocOptions(allocator, std.math.maxInt(usize), null, 1, 0);
+        defer allocator.free(source);
+
+        var ast = try std.zig.Ast.parse(allocator, source, .zon);
+        defer ast.deinit(allocator);
+
+        var buf: [2]std.zig.Ast.Node.Index = undefined;
+        const root = ast.fullStructInit(&buf, ast.nodes.items(.data)[0].lhs) orelse {
+            try stderr.writer().print("Error: Config file does not contain a struct literal\n", .{});
+            return error.InvalidConfig;
+        };
+
+        for (root.ast.fields) |field| {
+            const name = ast.tokenSlice(ast.firstToken(field) - 2);
+            const slice = ast.tokenSlice(ast.firstToken(field));
+            const value = if (ast.tokens.get(ast.firstToken(field)).tag == .identifier and std.mem.eql(u8, slice, "true"))
+                true
+            else if (ast.tokens.get(ast.firstToken(field)).tag == .identifier and std.mem.eql(u8, slice, "false"))
+                false
+            else {
+                try stderr.writer().print("Error: Expected a bool for field {s} in config file\n", .{name});
+                return error.InvalidConfig;
+            };
+            const field_ptr = blk: {
+                inline for (std.meta.fields(DisplayOptions)) |opt_field| {
+                    if (std.mem.eql(u8, name, opt_field.name)) break :blk &@field(options, opt_field.name);
+                }
+                try stderr.writer().print("Error: Invalid field in config file: {s}\n", .{name});
+                return error.InvalidConfig;
+            };
+            field_ptr.* = value;
+        }
+    }
+
+    // Environment variables
+    if (envs.get("NO_COLOR")) |s| {
+        if (!std.mem.eql(u8, s, "")) options.color = false;
+    }
+
+    // Flags
+    if (args.color) |color| options.color = color;
+    if (args.uppercase) |uppercase| options.uppercase = uppercase;
+    if (args.show_size) |show_size| options.show_size = show_size;
+    if (args.show_offset) |show_offset| options.show_offset = show_offset;
+    if (args.show_ascii) |show_ascii| options.show_ascii = show_ascii;
+
+    return options;
+}


### PR DESCRIPTION
For better code readability, move all option/configuration logic to a new file: `options.zig`.