### PR TITLE
Add `--parser` arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ The command should be used as `hevi <file> [flags]`. The flags are described [be
 | `--offset`/`--no-offset`         | Enable and disable showing the offset                   |
 | `--acii`/`--no-ascii`            | Enable and disable ASCII interpretation                 |
 | `--skip-lines`/`--no-skip-lines` | Enable and disable skipping of identical lines          |
+| `--parser`                       | Specify the parser to use. For a list use `hevi --help` |
 
 ### Environment variables
 The `NO_COLOR` variable is supported, and disables color (see <https://no-color.org/>) printing. Note that it can be overwritten by an explicit `--color`.

--- a/src/argparse.zig
+++ b/src/argparse.zig
@@ -1,6 +1,8 @@
 const build_options = @import("build_options");
 const std = @import("std");
 
+const parsers = @import("parser.zig").parsers;
+
 pub const ParseResult = struct {
     filename: []const u8,
     color: ?bool,
@@ -37,6 +39,19 @@ fn printError(comptime fmt: []const u8, args: anytype) noreturn {
 }
 
 fn printHelp() noreturn {
+    const parser_list: [parsers.len][]const u8 = comptime v: {
+        var list: [parsers.len][]const u8 = undefined;
+        var pos: usize = 0;
+        for (parsers) |parser| {
+            var split = std.mem.splitAny(u8, @typeName(parser), ".");
+            _ = split.first();
+
+            list[pos] = split.next().?;
+            pos += 1;
+        }
+        break :v list;
+    };
+
     std.debug.print(
         \\hevi - hex viewer
         \\
@@ -53,8 +68,18 @@ fn printHelp() noreturn {
         \\  --ascii, --no-ascii             Enable or disable the ASCII output
         \\  --skip-lines, --no-skip-lines   Enable or disable skipping of identical lines
         \\  --parser                        Specify the parser to use. Available parsers:
-        \\                                      - data
-        \\                                      - elf
+        \\
+    , .{});
+
+    for (parser_list) |parser| {
+        // How many tabs (4 spaces) we want to print
+        for (0..9) |_| {
+            std.debug.print("    ", .{});
+        }
+        std.debug.print("- {s}\n", .{parser});
+    }
+
+    std.debug.print(
         \\
         \\Made by Arnau478
         \\

--- a/src/main.zig
+++ b/src/main.zig
@@ -257,7 +257,7 @@ pub fn main() !void {
 pub fn dump(data: []const u8, writer: std.io.AnyWriter, options: DisplayOptions) !void {
     var fbs = std.io.fixedBufferStream(data);
 
-    const colors = try parser.getColors(allocator, fbs.reader().any());
+    const colors = try parser.getColors(allocator, fbs.reader().any(), options);
     defer allocator.free(colors);
 
     fbs.reset();

--- a/src/main.zig
+++ b/src/main.zig
@@ -277,6 +277,8 @@ pub fn dump(data: []const u8, writer: std.io.AnyWriter, options: DisplayOptions)
         writer,
         options,
     );
+
+    options.deinit();
 }
 
 fn testDump(expected: []const u8, input: []const u8, options: DisplayOptions) !void {

--- a/src/main.zig
+++ b/src/main.zig
@@ -300,6 +300,7 @@ test "basic dump" {
             .show_ascii = false,
             .skip_lines = false,
             .show_offset = false,
+            .parser = null,
         },
     );
 }
@@ -315,6 +316,7 @@ test "empty dump" {
             .show_ascii = false,
             .skip_lines = false,
             .show_offset = false,
+            .parser = null,
         },
     );
 }

--- a/src/options.zig
+++ b/src/options.zig
@@ -106,7 +106,7 @@ pub fn getOptions(args: argparse.ParseResult, stdout: std.fs.File) !DisplayOptio
                             try stderr.writer().print("Error: expected a bool for field {s} in config file\n", .{name});
                             return error.InvalidConfig;
                         },
-                        DisplayOptions.OptionString, ?DisplayOptions.OptionString => .{ .is_allocated = true, .string = std.mem.trim(u8, allocator.dupe(u8, value) catch @panic("OOM"), "\"") },
+                        DisplayOptions.OptionString, ?DisplayOptions.OptionString => .{ .is_allocated = true, .string = std.mem.trim(u8, try allocator.dupe(u8, value), "\"") },
                         else => {
                             try stderr.writer().print("Error: expected a {s} for field {s} in config file\n", .{ @typeName(opt_field.type), name });
                             return error.InvalidConfig;

--- a/src/options.zig
+++ b/src/options.zig
@@ -11,6 +11,7 @@ pub const DisplayOptions = struct {
     show_offset: bool,
     show_ascii: bool,
     skip_lines: bool,
+    parser: ?[]const u8,
 };
 
 fn openConfigFile(env_map: std.process.EnvMap) ?std.fs.File {
@@ -43,6 +44,7 @@ pub fn getOptions(args: argparse.ParseResult, stdout: std.fs.File) !DisplayOptio
         .show_offset = true,
         .show_ascii = true,
         .skip_lines = true,
+        .parser = null,
     };
 
     // Config file
@@ -77,7 +79,7 @@ pub fn getOptions(args: argparse.ParseResult, stdout: std.fs.File) !DisplayOptio
             };
             const field_ptr = blk: {
                 inline for (std.meta.fields(DisplayOptions)) |opt_field| {
-                    if (std.mem.eql(u8, name, opt_field.name)) break :blk &@field(options, opt_field.name);
+                    if (std.mem.eql(u8, name, opt_field.name) and opt_field.type == bool) break :blk &@field(options, opt_field.name);
                 }
                 try stderr.writer().print("Error: Invalid field in config file: {s}\n", .{name});
                 return error.InvalidConfig;
@@ -98,6 +100,7 @@ pub fn getOptions(args: argparse.ParseResult, stdout: std.fs.File) !DisplayOptio
     if (args.show_offset) |show_offset| options.show_offset = show_offset;
     if (args.show_ascii) |show_ascii| options.show_ascii = show_ascii;
     if (args.skip_lines) |skip_lines| options.skip_lines = skip_lines;
+    if (args.parser) |parser| options.parser = parser;
 
     return options;
 }

--- a/src/options.zig
+++ b/src/options.zig
@@ -11,7 +11,26 @@ pub const DisplayOptions = struct {
     show_offset: bool,
     show_ascii: bool,
     skip_lines: bool,
-    parser: ?[]const u8,
+    parser: ?OptionString,
+
+    pub const OptionString = struct {
+        is_allocated: bool = false,
+        string: []const u8,
+
+        pub fn safeSet(options: *DisplayOptions, s: []const u8) void {
+            if (options.parser) |parser| {
+                if (parser.is_allocated) allocator.free(parser.string);
+            }
+
+            options.parser = .{ .string = s };
+        }
+    };
+
+    pub fn deinit(self: @This()) void {
+        if (self.parser) |parser| {
+            if (parser.is_allocated) allocator.free(parser.string);
+        }
+    }
 };
 
 fn openConfigFile(env_map: std.process.EnvMap) ?std.fs.File {
@@ -69,22 +88,32 @@ pub fn getOptions(args: argparse.ParseResult, stdout: std.fs.File) !DisplayOptio
         for (root.ast.fields) |field| {
             const name = ast.tokenSlice(ast.firstToken(field) - 2);
             const slice = ast.tokenSlice(ast.firstToken(field));
-            const value = if (ast.tokens.get(ast.firstToken(field)).tag == .identifier and std.mem.eql(u8, slice, "true"))
-                true
-            else if (ast.tokens.get(ast.firstToken(field)).tag == .identifier and std.mem.eql(u8, slice, "false"))
-                false
+            const value = if (ast.tokens.get(ast.firstToken(field)).tag == .identifier or ast.tokens.get(ast.firstToken(field)).tag == .string_literal)
+                slice
             else {
-                try stderr.writer().print("Error: Expected a bool for field {s} in config file\n", .{name});
+                try stderr.writer().print("Error: invalid config found\n", .{});
                 return error.InvalidConfig;
             };
-            const field_ptr = blk: {
-                inline for (std.meta.fields(DisplayOptions)) |opt_field| {
-                    if (std.mem.eql(u8, name, opt_field.name) and opt_field.type == bool) break :blk &@field(options, opt_field.name);
+
+            inline for (std.meta.fields(DisplayOptions)) |opt_field| {
+                if (std.mem.eql(u8, name, opt_field.name)) {
+                    @field(options, opt_field.name) = switch (opt_field.type) {
+                        bool => if (std.mem.eql(u8, value, "false"))
+                            false
+                        else if (std.mem.eql(u8, value, "true"))
+                            true
+                        else {
+                            try stderr.writer().print("Error: expected a bool for field {s} in config file\n", .{name});
+                            return error.InvalidConfig;
+                        },
+                        DisplayOptions.OptionString, ?DisplayOptions.OptionString => .{ .is_allocated = true, .string = std.mem.trim(u8, allocator.dupe(u8, value) catch @panic("OOM"), "\"") },
+                        else => {
+                            try stderr.writer().print("Error: expected a {s} for field {s} in config file\n", .{ @typeName(opt_field.type), name });
+                            return error.InvalidConfig;
+                        },
+                    };
                 }
-                try stderr.writer().print("Error: Invalid field in config file: {s}\n", .{name});
-                return error.InvalidConfig;
-            };
-            field_ptr.* = value;
+            }
         }
     }
 
@@ -100,7 +129,7 @@ pub fn getOptions(args: argparse.ParseResult, stdout: std.fs.File) !DisplayOptio
     if (args.show_offset) |show_offset| options.show_offset = show_offset;
     if (args.show_ascii) |show_ascii| options.show_ascii = show_ascii;
     if (args.skip_lines) |skip_lines| options.skip_lines = skip_lines;
-    if (args.parser) |parser| options.parser = parser;
+    if (args.parser) |parser| DisplayOptions.OptionString.safeSet(&options, parser);
 
     return options;
 }

--- a/src/parser.zig
+++ b/src/parser.zig
@@ -17,7 +17,7 @@ pub fn getColors(allocator: std.mem.Allocator, reader: std.io.AnyReader, options
         if (options.parser) |p| {
             var split = std.mem.splitAny(u8, @typeName(parser), ".");
             _ = split.first();
-            if (std.mem.eql(u8, split.next().?, p)) {
+            if (std.mem.eql(u8, split.next().?, p.string)) {
                 parser.getColors(colors, data);
                 return colors;
             }

--- a/src/parser.zig
+++ b/src/parser.zig
@@ -21,6 +21,9 @@ pub fn getColors(allocator: std.mem.Allocator, reader: std.io.AnyReader, options
                 if (parser.matches(data)) {
                     parser.getColors(colors, data);
                     return colors;
+                } else {
+                    std.debug.print("Error: the specified parser doesn't match the file format!\n", .{});
+                    std.process.exit(1);
                 }
             }
         } else if (parser.matches(data)) {

--- a/src/parser.zig
+++ b/src/parser.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const DisplayOptions = @import("options.zig").DisplayOptions;
 const PaletteColor = @import("main.zig").PaletteColor;
 
-const parsers = &.{
+pub const parsers = &.{
     @import("parsers/elf.zig"),
     @import("parsers/data.zig"),
 };

--- a/src/parser.zig
+++ b/src/parser.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const DisplayOptions = @import("options.zig").DisplayOptions;
 const PaletteColor = @import("main.zig").PaletteColor;
 
 const parsers = &.{
@@ -6,14 +7,21 @@ const parsers = &.{
     @import("parsers/data.zig"),
 };
 
-pub fn getColors(allocator: std.mem.Allocator, reader: std.io.AnyReader) ![]const PaletteColor {
+pub fn getColors(allocator: std.mem.Allocator, reader: std.io.AnyReader, options: DisplayOptions) ![]const PaletteColor {
     const data = try reader.readAllAlloc(allocator, std.math.maxInt(usize));
     defer allocator.free(data);
 
     const colors = try allocator.alloc(PaletteColor, data.len);
 
     inline for (parsers) |parser| {
-        if (parser.matches(data)) {
+        if (options.parser) |p| {
+            var split = std.mem.splitAny(u8, @typeName(parser), ".");
+            _ = split.first();
+            if (std.mem.eql(u8, split.next().?, p)) {
+                parser.getColors(colors, data);
+                return colors;
+            }
+        } else if (parser.matches(data)) {
             parser.getColors(colors, data);
             return colors;
         }

--- a/src/parser.zig
+++ b/src/parser.zig
@@ -18,8 +18,10 @@ pub fn getColors(allocator: std.mem.Allocator, reader: std.io.AnyReader, options
             var split = std.mem.splitAny(u8, @typeName(parser), ".");
             _ = split.first();
             if (std.mem.eql(u8, split.next().?, p.string)) {
-                parser.getColors(colors, data);
-                return colors;
+                if (parser.matches(data)) {
+                    parser.getColors(colors, data);
+                    return colors;
+                }
             }
         } else if (parser.matches(data)) {
             parser.getColors(colors, data);


### PR DESCRIPTION
This commit adds `--parser` argument to specify which parser to use to read the file.

~This is only an arg. There isn't any field in the config file to set a specific parser.~