### PR TITLE
Fix memory leak and deinit GPA

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -238,6 +238,8 @@ fn display(reader: std.io.AnyReader, colors: []const TextColor, writer: std.io.A
 }
 
 pub fn main() !void {
+    defer if (gpa.deinit() == .leak) std.debug.print("Error: MEMORY LEAK!\n", .{});
+
     const args = try std.process.argsAlloc(allocator);
     defer std.process.argsFree(allocator, args);
 


### PR DESCRIPTION
Fix a memory leak when joining strings to get the path to the config file and at the end of the program execution deinit the general purpose allocator.