### PR TITLE
Use `getOrEnableAnsiEscapeSupport`

### DIFF
--- a/src/options.zig
+++ b/src/options.zig
@@ -187,7 +187,7 @@ pub fn getOptions(allocator: std.mem.Allocator, args: argparse.ParseResult, stdo
 
     // Default values
     var options = hevi.DisplayOptions{
-        .color = stdout.supportsAnsiEscapeCodes(),
+        .color = stdout.getOrEnableAnsiEscapeSupport(),
         .uppercase = false,
         .show_size = true,
         .show_offset = true,


### PR DESCRIPTION
On Windows 10, support for ANSI escape code may be disabled, but it can be enabled.
Using `getOrEnableAnsiEscapeSupport` we enable ANSI escape code if supported.