### PR TITLE
chore(license): update to use `GPL-3.0-or-later`

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,4 +122,6 @@ Contributions are welcome! Even if you don't want to write code, you can help a 
 ## License
 See [LICENSE](LICENSE)
 
-[![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
+SPDX-License-Identifier: GPL-3.0-or-later
+
+[![License: GPL-3.0-or-later](https://img.shields.io/badge/License-GPL--3.0--or--later-blue.svg)](https://spdx.org/licenses/GPL-3.0-or-later.html)

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -36,7 +36,7 @@
     description = "A modern hex viewer";
 
     homePage = "https://arnau478.github.io/hevi/";
-    license = licenses.gpl3;
+    license = licenses.gpl3Plus;
     platforms = platforms.all;
   };
 }


### PR DESCRIPTION
👋 GPL-3.0 is deprecated by [SPDX](https://spdx.org/licenses/GPL-3.0) (replaced by [GPL-3.0-only](https://spdx.org/licenses/GPL-3.0-only) or [GPL-3.0-or-later](https://spdx.org/licenses/GPL-3.0-or-later)), and I just update to use GPL-3.0-or-later, which feels more appropriate for the project.  


