### PR TITLE
Update to zig 0.15.1

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
-const Ast = std.zig.Ast;
-
 const SemanticVersion = std.SemanticVersion;
+
+const build_zon = @import("build.zig.zon");
 
 const release_targets: []const std.Target.Query = &.{
     .{ .os_tag = .linux, .cpu_arch = .x86 },
@@ -19,23 +19,7 @@ fn getVersion(b: *std.Build) SemanticVersion {
         return SemanticVersion.parse(forced_ver) catch @panic("Unable to parse forced version string");
     }
 
-    var ast = Ast.parse(b.allocator, @embedFile("build.zig.zon"), .zon) catch @panic("OOM");
-    defer ast.deinit(b.allocator);
-
-    var buf: [2]Ast.Node.Index = undefined;
-    const build_zon = ast.fullStructInit(&buf, ast.nodes.items(.data)[0].lhs) orelse @panic("Cannot parse build.zig.zon");
-
-    var version: SemanticVersion = r: {
-        for (build_zon.ast.fields) |field| {
-            const field_name = ast.tokenSlice(ast.firstToken(field) - 2);
-
-            if (std.mem.eql(u8, field_name, "version")) {
-                const version_string = std.mem.trim(u8, ast.tokenSlice(ast.firstToken(field)), "\"");
-                break :r SemanticVersion.parse(version_string) catch @panic("Version parsing failed");
-            }
-        }
-        @panic("Unable to find 'version' in build.zig.zon");
-    };
+    var version = SemanticVersion.parse(build_zon.version) catch @panic("Version parsing failed");
 
     var code: u8 = undefined;
     const git_version_cmd = std.mem.trim(u8, b.runAllowFail(&[_][]const u8{
@@ -78,9 +62,11 @@ fn getVersion(b: *std.Build) SemanticVersion {
 fn addExe(b: *std.Build, target: std.Build.ResolvedTarget, optimize: std.builtin.OptimizeMode, pie: ?bool, release: bool, build_options: *std.Build.Step.Options, hevi_mod: *std.Build.Module) *std.Build.Step.Compile {
     const exe = b.addExecutable(.{
         .name = if (release) b.fmt("hevi-{s}-{s}", .{ @tagName(target.result.cpu.arch), @tagName(target.result.os.tag) }) else "hevi",
-        .root_source_file = b.path("src/main.zig"),
-        .target = target,
-        .optimize = optimize,
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/main.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
     });
 
     exe.pie = pie;
@@ -113,9 +99,11 @@ pub fn build(b: *std.Build) !void {
 
     const docs_obj = b.addObject(.{
         .name = "hevi",
-        .target = target,
-        .optimize = .Debug,
-        .root_source_file = b.path("src/hevi.zig"),
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/hevi.zig"),
+            .target = target,
+            .optimize = .Debug,
+        }),
     });
     docs_obj.root_module.addOptions("build_options", build_options);
 
@@ -154,9 +142,11 @@ pub fn build(b: *std.Build) !void {
     run_step.dependOn(&run_cmd.step);
 
     const exe_unit_tests = b.addTest(.{
-        .root_source_file = b.path("src/main.zig"),
-        .target = target,
-        .optimize = optimize,
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/main.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
     });
     exe_unit_tests.root_module.addImport("hevi", mod);
     exe_unit_tests.root_module.addOptions("build_options", build_options);
@@ -164,9 +154,11 @@ pub fn build(b: *std.Build) !void {
     const run_exe_unit_tests = b.addRunArtifact(exe_unit_tests);
 
     const mod_unit_tests = b.addTest(.{
-        .root_source_file = b.path("src/hevi.zig"),
-        .target = target,
-        .optimize = optimize,
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/hevi.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
     });
 
     const run_mod_unit_tests = b.addRunArtifact(mod_unit_tests);

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -2,15 +2,15 @@
     .name = .hevi,
     .version = "2.0.0",
     .fingerprint = 0xdcc10eb74ab2196e,
-    .minimum_zig_version = "0.14.0",
+    .minimum_zig_version = "0.15.1",
     .dependencies = .{
         .ziggy = .{
-            .url = "git+https://github.com/kristoff-it/ziggy#af41bdb5b1d64404c2ec7eb1d9de01083c0d2596",
-            .hash = "ziggy-0.1.0-kTg8v7rKBQCdELbScM186Uh4X3sxhBFgsdNpYcilLhDt",
+            .url = "git+https://github.com/kristoff-it/ziggy#4353b20ef2ac750e35c6d68e4eb2a07c2d7cf901",
+            .hash = "ziggy-0.1.0-kTg8v5pABgDztlefWHceH-Sh8tVveguFC61QkmLkIRaA",
         },
         .pennant = .{
-            .url = "git+https://github.com/Arnau478/pennant#67aee7c4761afe74d6ff9e2bc4a00131adcc582e",
-            .hash = "pennant-0.1.0-MwI8MANDAACAV-1TXYJwhyBCSg5EwnVD6fqsw1ma3VCn",
+            .url = "git+https://github.com/Arnau478/pennant#df76de01bcf06eb1dcb40dbf04f7c219c3a35a7d",
+            .hash = "pennant-0.1.0-MwI8MLhIAACFrJKPC3xmueUoBNGzlM0layBrNNLtNvOB",
         },
     },
     .paths = .{

--- a/src/NormalizedSize.zig
+++ b/src/NormalizedSize.zig
@@ -39,6 +39,6 @@ pub fn fromBytes(bytes: usize) NormalizedSize {
     return size;
 }
 
-pub fn format(self: NormalizedSize, comptime _: []const u8, _: std.fmt.FormatOptions, writer: anytype) !void {
+pub fn format(self: NormalizedSize, writer: *std.Io.Writer) !void {
     try writer.print("{d:.2} {s}", .{ self.magnitude, self.unit.getName() });
 }

--- a/src/hevi.zig
+++ b/src/hevi.zig
@@ -40,7 +40,7 @@ pub const TextColor = struct {
         };
     };
 
-    pub fn ansiCode(self: TextColor, writer: anytype) !void {
+    pub fn ansiCode(self: TextColor, writer: *std.Io.Writer) !void {
         if (self.foreground) |foreground| {
             switch (foreground) {
                 .standard => |standard| _ = try writer.write(switch (standard) {
@@ -187,10 +187,7 @@ pub const Parser = enum {
     }
 };
 
-fn getColors(allocator: std.mem.Allocator, reader: anytype, options: DisplayOptions) ![]const PaletteColor {
-    const data = try reader.readAllAlloc(allocator, std.math.maxInt(usize));
-    defer allocator.free(data);
-
+fn getColors(allocator: std.mem.Allocator, data: []const u8, options: DisplayOptions) ![]const PaletteColor {
     const colors = try allocator.alloc(PaletteColor, data.len);
 
     inline for (comptime std.enums.values(Parser)) |parser| {
@@ -226,7 +223,7 @@ const DisplayLineOptions = struct {
     raw: bool,
 };
 
-fn displayLine(line: []const u8, colors: []const TextColor, writer: anytype, options: DisplayLineOptions) !void {
+fn displayLine(line: []const u8, colors: []const TextColor, writer: *std.Io.Writer, options: DisplayLineOptions) !void {
     if (!options.raw) {
         if (options.color) {
             try writer.print("\x1b[2m|\x1b[0m ", .{});
@@ -288,7 +285,7 @@ fn displayLine(line: []const u8, colors: []const TextColor, writer: anytype, opt
     try writer.print("\n", .{});
 }
 
-fn printBuffer(line: []const u8, colors: []const TextColor, count: usize, writer: anytype, options: DisplayOptions) !void {
+fn printBuffer(line: []const u8, colors: []const TextColor, count: usize, writer: *std.Io.Writer, options: DisplayOptions) !void {
     if (options.show_offset) {
         if (options.uppercase) {
             try writer.print("{X:0>8} ", .{count});
@@ -303,7 +300,7 @@ fn printBuffer(line: []const u8, colors: []const TextColor, count: usize, writer
     });
 }
 
-fn display(reader: anytype, colors: []const TextColor, raw_writer: anytype, options: DisplayOptions) !void {
+fn display(fixed_reader: *std.Io.Reader, colors: []const TextColor, writer: *std.Io.Writer, options: DisplayOptions) !void {
     var count: usize = 0;
 
     var buf: [16]u8 = undefined;
@@ -313,11 +310,8 @@ fn display(reader: anytype, colors: []const TextColor, raw_writer: anytype, opti
     var previous_line_len: ?usize = null;
     var lines_skipped: usize = 0;
 
-    var buf_writer = std.io.bufferedWriter(raw_writer);
-    const writer = buf_writer.writer();
-
     while (true) {
-        const line_len = try reader.readAll(&buf);
+        const line_len = try fixed_reader.readSliceShort(&buf);
 
         if (line_len == 0) {
             switch (lines_skipped) {
@@ -363,26 +357,22 @@ fn display(reader: anytype, colors: []const TextColor, raw_writer: anytype, opti
 
         count += line_len;
 
-        try buf_writer.flush();
+        try writer.flush();
     }
 
     if (options.show_size) {
         if (count < 1024) {
             try writer.print("File size: {} bytes\n", .{count});
-        } else try writer.print("File size: {} bytes ({})\n", .{ count, NormalizedSize.fromBytes(count) });
+        } else try writer.print("File size: {} bytes ({f})\n", .{ count, NormalizedSize.fromBytes(count) });
     }
 
-    try buf_writer.flush();
+    try writer.flush();
 }
 
 /// Dump `data` to `writer`
-pub fn dump(allocator: std.mem.Allocator, data: []const u8, writer: anytype, options: DisplayOptions) !void {
-    var fbs = std.io.fixedBufferStream(data);
-
-    const colors = try getColors(allocator, fbs.reader(), options);
+pub fn dump(allocator: std.mem.Allocator, data: []const u8, writer: *std.Io.Writer, options: DisplayOptions) !void {
+    const colors = try getColors(allocator, data, options);
     defer allocator.free(colors);
-
-    fbs.reset();
 
     const text_colors = try allocator.alloc(TextColor, colors.len);
     defer allocator.free(text_colors);
@@ -402,8 +392,9 @@ pub fn dump(allocator: std.mem.Allocator, data: []const u8, writer: anytype, opt
         new_options.skip_lines = false;
     }
 
+    var fixed_reader = std.Io.Reader.fixed(data);
     try display(
-        fbs.reader(),
+        &fixed_reader,
         text_colors,
         writer,
         new_options,
@@ -415,13 +406,12 @@ test {
 }
 
 fn testDump(expected: []const u8, input: []const u8, options: DisplayOptions) !void {
-    var out = std.ArrayList(u8).init(std.testing.allocator);
+    var out: std.Io.Writer.Allocating = try .initCapacity(std.testing.allocator, expected.len);
     defer out.deinit();
-    try out.ensureTotalCapacity(expected.len);
 
-    try dump(std.testing.allocator, input, out.writer(), options);
+    try dump(std.testing.allocator, input, &out.writer, options);
 
-    try std.testing.expectEqualSlices(u8, expected, out.items);
+    try std.testing.expectEqualSlices(u8, expected, out.written());
 }
 
 test "basic dump" {

--- a/src/main.zig
+++ b/src/main.zig
@@ -11,14 +11,16 @@ pub const std_options = std.Options{
 fn logFn(comptime message_level: std.log.Level, comptime scope: @Type(.enum_literal), comptime format: []const u8, args: anytype) void {
     const level_txt = comptime message_level.asText();
     const prefix2 = if (scope == .default) ": " else "(" ++ @tagName(scope) ++ "): ";
-    const stderr = std.io.getStdErr();
-    var bw = std.io.bufferedWriter(stderr.writer());
-    const writer = bw.writer();
+
+    var stderr_buffer: [4096]u8 = undefined;
+    var stderr_file = std.fs.File.stderr();
+    var stderr_writer = stderr_file.writer(&stderr_buffer);
+    const stderr = &stderr_writer.interface;
 
     std.debug.lockStdErr();
     defer std.debug.unlockStdErr();
 
-    const log_color = stderr.supportsAnsiEscapeCodes();
+    const log_color = stderr_file.supportsAnsiEscapeCodes();
 
     const col = switch (message_level) {
         .err => "31",
@@ -28,12 +30,12 @@ fn logFn(comptime message_level: std.log.Level, comptime scope: @Type(.enum_lite
     };
 
     nosuspend {
-        writer.print(
+        stderr.print(
             "{s}{s}{s}" ++ level_txt ++ "{s}",
             if (log_color) .{ "\x1b[", col, "m\x1b[1m", "\x1b[0m" } else .{ "", "", "", "" },
         ) catch return;
-        writer.print(prefix2 ++ format ++ "\n", args) catch return;
-        bw.flush() catch return;
+        stderr.print(prefix2 ++ format ++ "\n", args) catch return;
+        stderr.flush() catch return;
     }
 }
 
@@ -42,7 +44,7 @@ pub fn fail(comptime fmt: []const u8, args: anytype) noreturn {
     std.process.exit(1);
 }
 
-fn printPalette(opts: hevi.DisplayOptions, writer: anytype) !void {
+fn printPalette(opts: hevi.DisplayOptions, writer: *std.Io.Writer) std.Io.Writer.Error!void {
     try writer.print("                  (alt)    (accent)\n", .{});
     try writer.print("(main)   ", .{});
     try opts.palette.normal.ansiCode(writer);
@@ -154,9 +156,12 @@ pub fn main() void {
 
     switch (args_res) {
         .valid => |args| {
-            const stdout = std.io.getStdOut();
+            var stdout_buffer: [4096]u8 = undefined;
+            var stdout_file = std.fs.File.stdout();
+            var stdout_writer = stdout_file.writer(&stdout_buffer);
+            const stdout = &stdout_writer.interface;
 
-            const opts = options.getOptions(allocator, args.options, stdout) catch |err| switch (err) {
+            const opts = options.getOptions(allocator, args.options, stdout_file) catch |err| switch (err) {
                 error.InvalidConfig => fail("Invalid config found", .{}),
                 else => fail("Error getting options and config file", .{}),
             };
@@ -171,7 +176,7 @@ pub fn main() void {
             } else if (args.options.version) {
                 printVersion();
             } else if (args.options.@"show-palette") {
-                printPalette(opts, stdout.writer()) catch |err| switch (err) {
+                printPalette(opts, stdout) catch |err| switch (err) {
                     else => fail("{s}", .{@errorName(err)}),
                 };
             } else {
@@ -181,7 +186,7 @@ pub fn main() void {
                     const filename = if (is_stdin) "<stdin>" else true_filename;
 
                     const file = if (is_stdin)
-                        std.io.getStdIn()
+                        std.fs.File.stdin()
                     else
                         std.fs.cwd().openFile(filename, .{}) catch |err| switch (err) {
                             error.FileNotFound => fail("{s} not found", .{filename}),
@@ -198,10 +203,9 @@ pub fn main() void {
 
                     defer allocator.free(data);
 
-                    hevi.dump(allocator, data, stdout.writer(), opts) catch |err| switch (err) {
+                    hevi.dump(allocator, data, stdout, opts) catch |err| switch (err) {
                         error.NonMatchingParser => fail("{s} does not match parser {s}", .{ filename, @tagName(opts.parser.?) }),
                         error.OutOfMemory => fail("Out of memory", .{}),
-                        error.BrokenPipe => fail("Broken pipe", .{}),
                         else => fail("Error writing to stdout: {s}", .{@errorName(err)}),
                     };
                 } else {
@@ -214,9 +218,11 @@ pub fn main() void {
                     std.process.exit(1);
                 }
             }
+
+            stdout.flush() catch fail("Cannot flush", .{});
         },
         .err => |err| {
-            fail("{}", .{err});
+            fail("{f}", .{err});
         },
     }
 }

--- a/src/options.zig
+++ b/src/options.zig
@@ -204,7 +204,7 @@ pub fn getOptions(allocator: std.mem.Allocator, args: root.CliOptions, stdout: s
             allocator.free(tuple[1]);
         }
 
-        const source = try tuple[0].readToEndAllocOptions(allocator, std.math.maxInt(usize), null, 1, 0);
+        const source = try tuple[0].readToEndAllocOptions(allocator, std.math.maxInt(usize), null, .of(u8), 0);
         defer allocator.free(source);
 
         if (source.len != 0) {
@@ -218,7 +218,7 @@ pub fn getOptions(allocator: std.mem.Allocator, args: root.CliOptions, stdout: s
                 .diagnostic = &diag,
             }) catch |err| switch (err) {
                 error.OutOfMemory, error.Overflow => return error.OutOfMemory,
-                error.Syntax => {
+                error.Syntax, error.MissingFrontmatter, error.OpenFrontmatter => {
                     std.log.err("{}", .{diag});
                     return error.InvalidConfig;
                 },


### PR DESCRIPTION
For the stdout and stderr buffers, I used the same size as in [this zig 0.15.1 release example](https://ziglang.org/download/0.15.1/release-notes.html#BufferedWriter-Deleted).
Let me know if you think a different buffer size would be more appropriate.